### PR TITLE
4312 time shift function in pivot no longer working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.21.3
+
+- Better handle `undefined` in druid groupBys
+
 ## 0.21.2
 
 - Add `rebaseOnStart` to `Range`

--- a/build/external/baseExternal.d.ts
+++ b/build/external/baseExternal.d.ts
@@ -110,8 +110,10 @@ export declare abstract class External {
     static getSimpleInflater(type: PlyType, label: string): Inflater;
     static booleanInflaterFactory(label: string): Inflater;
     static timeRangeInflaterFactory(label: string, duration: Duration, timezone: Timezone): Inflater;
+    static nullInflaterFactory(label: string): Inflater;
     static numberRangeInflaterFactory(label: string, rangeSize: number): Inflater;
     static numberInflaterFactory(label: string): Inflater;
+    static stringInflaterFactory(label: string): Inflater;
     static timeInflaterFactory(label: string): Inflater;
     static setStringInflaterFactory(label: string): Inflater;
     static setCardinalityInflaterFactory(label: string): Inflater;

--- a/build/external/baseExternal.js
+++ b/build/external/baseExternal.js
@@ -358,13 +358,19 @@ var External = (function () {
     External.getSimpleInflater = function (type, label) {
         switch (type) {
             case 'BOOLEAN': return External.booleanInflaterFactory(label);
+            case 'NULL': return External.nullInflaterFactory(label);
             case 'NUMBER': return External.numberInflaterFactory(label);
+            case 'STRING': return External.stringInflaterFactory(label);
             case 'TIME': return External.timeInflaterFactory(label);
             default: return null;
         }
     };
     External.booleanInflaterFactory = function (label) {
         return function (d) {
+            if (typeof d[label] === 'undefined') {
+                d[label] = null;
+                return;
+            }
             var v = '' + d[label];
             switch (v) {
                 case 'null':
@@ -394,6 +400,14 @@ var External = (function () {
             d[label] = new TimeRange({ start: start, end: duration.shift(start, timezone) });
         };
     };
+    External.nullInflaterFactory = function (label) {
+        return function (d) {
+            var v = d[label];
+            if ('' + v === "null" || typeof v === 'undefined') {
+                d[label] = null;
+            }
+        };
+    };
     External.numberRangeInflaterFactory = function (label, rangeSize) {
         return function (d) {
             var v = d[label];
@@ -416,10 +430,18 @@ var External = (function () {
             d[label] = isNaN(v) ? null : v;
         };
     };
+    External.stringInflaterFactory = function (label) {
+        return function (d) {
+            var v = d[label];
+            if (typeof v === 'undefined') {
+                d[label] = null;
+            }
+        };
+    };
     External.timeInflaterFactory = function (label) {
         return function (d) {
             var v = d[label];
-            if ('' + v === "null") {
+            if ('' + v === "null" || typeof v === 'undefined') {
                 d[label] = null;
                 return;
             }

--- a/build/external/utils/druidExpressionBuilder.js
+++ b/build/external/utils/druidExpressionBuilder.js
@@ -179,11 +179,7 @@ var DruidExpressionBuilder = (function () {
                         return "(cast(" + ex1_1 + ",'DOUBLE')/" + ex2 + ")";
                     }
                     else {
-                        var nullValue = 'null';
-                        if (this.versionBefore('0.13.0')) {
-                            nullValue = '0';
-                        }
-                        return "if(" + ex2 + "!=0,(cast(" + ex1_1 + ",'DOUBLE')/" + ex2 + ")," + nullValue + ")";
+                        return "if(" + ex2 + "!=0,(cast(" + ex1_1 + ",'DOUBLE')/" + ex2 + "),0)";
                     }
                 }
                 else if (expression instanceof PowerExpression) {

--- a/build/plywood-lite.js
+++ b/build/plywood-lite.js
@@ -30,7 +30,7 @@ var parseISODate = Chronoshift.parseISODate;
 
 var dummyObject = {};
 
-var version = exports.version = '0.21.2';
+var version = exports.version = '0.21.3';
 var promiseWhile = exports.promiseWhile = function(condition, action) {
     var loop = function () {
         if (!condition())
@@ -8506,13 +8506,19 @@ var External = (function () {
     External.getSimpleInflater = function (type, label) {
         switch (type) {
             case 'BOOLEAN': return External.booleanInflaterFactory(label);
+            case 'NULL': return External.nullInflaterFactory(label);
             case 'NUMBER': return External.numberInflaterFactory(label);
+            case 'STRING': return External.stringInflaterFactory(label);
             case 'TIME': return External.timeInflaterFactory(label);
             default: return null;
         }
     };
     External.booleanInflaterFactory = function (label) {
         return function (d) {
+            if (typeof d[label] === 'undefined') {
+                d[label] = null;
+                return;
+            }
             var v = '' + d[label];
             switch (v) {
                 case 'null':
@@ -8542,6 +8548,14 @@ var External = (function () {
             d[label] = new TimeRange({ start: start, end: duration.shift(start, timezone) });
         };
     };
+    External.nullInflaterFactory = function (label) {
+        return function (d) {
+            var v = d[label];
+            if ('' + v === "null" || typeof v === 'undefined') {
+                d[label] = null;
+            }
+        };
+    };
     External.numberRangeInflaterFactory = function (label, rangeSize) {
         return function (d) {
             var v = d[label];
@@ -8564,10 +8578,18 @@ var External = (function () {
             d[label] = isNaN(v) ? null : v;
         };
     };
+    External.stringInflaterFactory = function (label) {
+        return function (d) {
+            var v = d[label];
+            if (typeof v === 'undefined') {
+                d[label] = null;
+            }
+        };
+    };
     External.timeInflaterFactory = function (label) {
         return function (d) {
             var v = d[label];
-            if ('' + v === "null") {
+            if ('' + v === "null" || typeof v === 'undefined') {
                 d[label] = null;
                 return;
             }

--- a/build/plywood.js
+++ b/build/plywood.js
@@ -10422,11 +10422,7 @@ var DruidExpressionBuilder = (function () {
                         return "(cast(" + ex1_1 + ",'DOUBLE')/" + ex2 + ")";
                     }
                     else {
-                        var nullValue = 'null';
-                        if (this.versionBefore('0.13.0')) {
-                            nullValue = '0';
-                        }
-                        return "if(" + ex2 + "!=0,(cast(" + ex1_1 + ",'DOUBLE')/" + ex2 + ")," + nullValue + ")";
+                        return "if(" + ex2 + "!=0,(cast(" + ex1_1 + ",'DOUBLE')/" + ex2 + "),0)";
                     }
                 }
                 else if (expression instanceof PowerExpression) {

--- a/build/plywood.js
+++ b/build/plywood.js
@@ -30,7 +30,7 @@ var parseISODate = Chronoshift.parseISODate;
 
 var dummyObject = {};
 
-var version = exports.version = '0.21.2';
+var version = exports.version = '0.21.3';
 var verboseRequesterFactory = exports.verboseRequesterFactory = function(parameters) {
     var requester = parameters.requester;
     var myName = parameters.name || 'rq' + String(Math.random()).substr(2, 5);
@@ -9156,13 +9156,19 @@ var External = (function () {
     External.getSimpleInflater = function (type, label) {
         switch (type) {
             case 'BOOLEAN': return External.booleanInflaterFactory(label);
+            case 'NULL': return External.nullInflaterFactory(label);
             case 'NUMBER': return External.numberInflaterFactory(label);
+            case 'STRING': return External.stringInflaterFactory(label);
             case 'TIME': return External.timeInflaterFactory(label);
             default: return null;
         }
     };
     External.booleanInflaterFactory = function (label) {
         return function (d) {
+            if (typeof d[label] === 'undefined') {
+                d[label] = null;
+                return;
+            }
             var v = '' + d[label];
             switch (v) {
                 case 'null':
@@ -9192,6 +9198,14 @@ var External = (function () {
             d[label] = new TimeRange({ start: start, end: duration.shift(start, timezone) });
         };
     };
+    External.nullInflaterFactory = function (label) {
+        return function (d) {
+            var v = d[label];
+            if ('' + v === "null" || typeof v === 'undefined') {
+                d[label] = null;
+            }
+        };
+    };
     External.numberRangeInflaterFactory = function (label, rangeSize) {
         return function (d) {
             var v = d[label];
@@ -9214,10 +9228,18 @@ var External = (function () {
             d[label] = isNaN(v) ? null : v;
         };
     };
+    External.stringInflaterFactory = function (label) {
+        return function (d) {
+            var v = d[label];
+            if (typeof v === 'undefined') {
+                d[label] = null;
+            }
+        };
+    };
     External.timeInflaterFactory = function (label) {
         return function (d) {
             var v = d[label];
-            if ('' + v === "null") {
+            if ('' + v === "null" || typeof v === 'undefined') {
                 d[label] = null;
                 return;
             }

--- a/build/version.js
+++ b/build/version.js
@@ -1,1 +1,1 @@
-export var version = '0.21.2';
+export var version = '0.21.3';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plywood",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plywood",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "A query planner and executor",
   "keywords": [
     "split",

--- a/src/external/baseExternal.ts
+++ b/src/external/baseExternal.ts
@@ -452,7 +452,9 @@ export abstract class External {
   static getSimpleInflater(type: PlyType, label: string): Inflater {
     switch (type) {
       case 'BOOLEAN': return External.booleanInflaterFactory(label);
+      case 'NULL': return External.nullInflaterFactory(label);
       case 'NUMBER': return External.numberInflaterFactory(label);
+      case 'STRING': return External.stringInflaterFactory(label);
       case 'TIME': return External.timeInflaterFactory(label);
       default: return null;
     }
@@ -460,6 +462,11 @@ export abstract class External {
 
   static booleanInflaterFactory(label: string): Inflater {
     return (d: any) => {
+      if (typeof d[label] === 'undefined') {
+        d[label] = null;
+        return;
+      }
+
       let v = '' + d[label];
       switch (v) {
         case 'null':
@@ -495,6 +502,15 @@ export abstract class External {
     };
   }
 
+  static nullInflaterFactory(label: string): Inflater {
+    return (d: any) => {
+      let v = d[label];
+      if ('' + v === "null" || typeof v === 'undefined') {
+        d[label] = null;
+      }
+    };
+  }
+
   static numberRangeInflaterFactory(label: string, rangeSize: number): Inflater  {
     return (d: any) => {
       let v = d[label];
@@ -521,10 +537,19 @@ export abstract class External {
     };
   }
 
+  static stringInflaterFactory(label: string): Inflater  {
+    return (d: any) => {
+      let v = d[label];
+      if (typeof v === 'undefined') {
+        d[label] = null;
+      }
+    };
+  }
+
   static timeInflaterFactory(label: string): Inflater  {
     return (d: any) => {
       let v = d[label];
-      if ('' + v === "null") {
+      if ('' + v === "null" || typeof v === 'undefined') {
         d[label] = null;
         return;
       }

--- a/src/external/utils/druidExpressionBuilder.ts
+++ b/src/external/utils/druidExpressionBuilder.ts
@@ -266,11 +266,7 @@ export class DruidExpressionBuilder {
           if (myExpression instanceof LiteralExpression) {
             return `(cast(${ex1},'DOUBLE')/${ex2})`;
           } else {
-            let nullValue = 'null';
-            if (this.versionBefore('0.13.0')) {
-              nullValue = '0';
-            }
-            return `if(${ex2}!=0,(cast(${ex1},'DOUBLE')/${ex2}),${nullValue})`;
+            return `if(${ex2}!=0,(cast(${ex1},'DOUBLE')/${ex2}),0)`;
           }
 
         } else if (expression instanceof PowerExpression) {

--- a/test/external/druidExternal.mocha.js
+++ b/test/external/druidExternal.mocha.js
@@ -457,7 +457,7 @@ describe("DruidExternal", () => {
           "type": "doubleSum"
         },
         {
-          "expression": "if(abs(\"added\")!=0,(cast((pow(\"added\",2)*\"deleted\"),'DOUBLE')/abs(\"added\")),null)",
+          "expression": "if(abs(\"added\")!=0,(cast((pow(\"added\",2)*\"deleted\"),'DOUBLE')/abs(\"added\")),0)",
           "name": "SumComplex",
           "type": "doubleSum"
         }
@@ -652,7 +652,7 @@ describe("DruidExternal", () => {
             "type": "double_up"
           },
           {
-            "expression": "(pow(abs((if(pow(abs(\"Count\"),0.5)!=0,(cast(\"!T_0\",'DOUBLE')/pow(abs(\"Count\"),0.5)),null)+(\"!T_1\"*100))),2)+\"!T_2\")",
+            "expression": "(pow(abs((if(pow(abs(\"Count\"),0.5)!=0,(cast(\"!T_0\",'DOUBLE')/pow(abs(\"Count\"),0.5)),0)+(\"!T_1\"*100))),2)+\"!T_2\")",
             "name": "Abs",
             "type": "expression"
           }

--- a/test/external/druidExternalNullType.mocha.js
+++ b/test/external/druidExternalNullType.mocha.js
@@ -359,7 +359,7 @@ describe("DruidExternal Null Type", () => {
           "type": "doubleSum"
         },
         {
-          "expression": "if(abs(\"added\")!=0,(cast((pow(\"added\",2)*\"deleted\"),'DOUBLE')/abs(\"added\")),null)",
+          "expression": "if(abs(\"added\")!=0,(cast((pow(\"added\",2)*\"deleted\"),'DOUBLE')/abs(\"added\")),0)",
           "name": "SumComplex",
           "type": "doubleSum"
         }
@@ -525,7 +525,7 @@ describe("DruidExternal Null Type", () => {
         "metric": "Count",
         "postAggregations": [
           {
-            "expression": "(pow(abs((if(pow(abs(\"Count\"),0.5)!=0,(cast(\"!T_0\",'DOUBLE')/pow(abs(\"Count\"),0.5)),null)+(\"!T_1\"*100))),2)+\"!T_2\")",
+            "expression": "(pow(abs((if(pow(abs(\"Count\"),0.5)!=0,(cast(\"!T_0\",'DOUBLE')/pow(abs(\"Count\"),0.5)),0)+(\"!T_1\"*100))),2)+\"!T_2\")",
             "name": "Abs",
             "type": "expression"
           }

--- a/test/external/druidExternalRollup.mocha.js
+++ b/test/external/druidExternalRollup.mocha.js
@@ -126,7 +126,7 @@ describe("DruidExternal Rollup", () => {
         "intervals": "2015-03-12T00Z/2015-03-19T00Z",
         "postAggregations": [
           {
-            "expression": "if(\"Count\"!=0,(cast(\"!T_0\",'DOUBLE')/\"Count\"),null)",
+            "expression": "if(\"Count\"!=0,(cast(\"!T_0\",'DOUBLE')/\"Count\"),0)",
             "name": "AvgAdded",
             "type": "expression"
           }
@@ -208,12 +208,12 @@ describe("DruidExternal Rollup", () => {
         "intervals": "2015-03-12T00Z/2015-03-19T00Z",
         "postAggregations": [
           {
-            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),null)",
+            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),0)",
             "name": "AvgEnAdded",
             "type": "expression"
           },
           {
-            "expression": "if(\"!T_3\"!=0,(cast(\"!T_2\",'DOUBLE')/\"!T_3\"),null)",
+            "expression": "if(\"!T_3\"!=0,(cast(\"!T_2\",'DOUBLE')/\"!T_3\"),0)",
             "name": "AvgHeDeleted",
             "type": "expression"
           }

--- a/test/external/external.mocha.js
+++ b/test/external/external.mocha.js
@@ -561,6 +561,144 @@ describe("External", () => {
     });
   });
 
+  describe(".getSimpleInflater inflates correctly", () => {
+    const label = 'testProperty';
+
+    function expectValueToInflate(inflater, value, mappedValue = value) {
+      const data = {[label]: value};
+      inflater(data);
+      expect(data).to.deep.equal({[label]: mappedValue});
+    }
+
+    function expectNullToInflate(inflater) {
+      expectValueToInflate(inflater, null);
+    }
+
+    function expectNullStringToInflate(inflater) {
+      expectValueToInflate(inflater, 'null', null);
+    }
+
+    function expectUndefinedToInflate(inflater) {
+      const data = {};
+      inflater(data);
+      expect(data).to.deep.equal({[label]: null});
+    }
+
+    describe("with NULL plytype", () => {
+      const inflater = External.getSimpleInflater('NULL', label);
+      it("and a null value", () => {
+        expectNullToInflate(inflater);
+      });
+
+      it("and a 'null' value", () => {
+        expectNullStringToInflate(inflater);
+      });
+
+      it("and an undefined value", () => {
+        expectUndefinedToInflate(inflater);
+      });
+    });
+
+    describe("with STRING plytype", () => {
+      const inflater = External.getSimpleInflater('STRING', label);
+      it("and a valid string", () => {
+        expectValueToInflate(inflater, "here's my string");
+      });
+
+      it("and a null value", () => {
+        expectNullToInflate(inflater);
+      });
+
+      // it.skip("and a 'null' value", () => {
+      //   expectNullStringToInflate(inflater);
+      // });
+
+      it("and an undefined value", () => {
+        expectUndefinedToInflate(inflater);
+      });
+    });
+
+    describe("with BOOLEAN plytype", () => {
+      const inflater = External.getSimpleInflater('BOOLEAN', label);
+      it("and a true value", () => {
+        expectValueToInflate(inflater, true);
+      });
+
+      it("and a false value", () => {
+        expectValueToInflate(inflater, false);
+      });
+
+      it("and a 'true' value", () => {
+        expectValueToInflate(inflater, 'true', true);
+      });
+
+      it("and a 'false' value", () => {
+        expectValueToInflate(inflater, 'false', false);
+      });
+
+      it("and a null value", () => {
+        expectNullToInflate(inflater);
+      });
+
+      it("and a 'null' value", () => {
+        expectNullStringToInflate(inflater);
+      });
+
+      it("and an undefined value", () => {
+        expectUndefinedToInflate(inflater);
+      });
+
+      it("and a '0' value", () => {
+        expectValueToInflate(inflater, '0', false);
+      });
+
+      it("and a '1' value", () => {
+        expectValueToInflate(inflater, '1', true);
+      });
+
+      it("and an unrecognized invalid value", () => {
+        expect(() => inflater({[label]: 'not a boolean'})).to.throw();
+      });
+    });
+
+    describe("with NUMBER plytype", () => {
+      const inflater = External.getSimpleInflater('NUMBER', label);
+      it("and a valid number", () => {
+        expectValueToInflate(inflater, 123);
+      });
+
+      it("and a null value", () => {
+        expectNullToInflate(inflater);
+      });
+
+      it("and a 'null' value", () => {
+        expectNullStringToInflate(inflater);
+      });
+
+      it("and an undefined value", () => {
+        expectUndefinedToInflate(inflater);
+      });
+    });
+
+    describe("with TIME plytype", () => {
+      const inflater = External.getSimpleInflater('TIME', label);
+      it("and a valid time", () => {
+        expectValueToInflate(inflater, new Date(1));
+      });
+
+      it("and a null value", () => {
+        expectNullToInflate(inflater);
+      });
+
+      it("and a 'null' value", () => {
+        expectNullStringToInflate(inflater);
+      });
+
+      it("and an undefined value", () => {
+        expectUndefinedToInflate(inflater);
+      });
+    });
+  });
 
   describe("#hasAttribute", () => {
     let rawExternal = External.fromJS({

--- a/test/simulate/simulateDruid.mocha.js
+++ b/test/simulate/simulateDruid.mocha.js
@@ -348,7 +348,7 @@ describe("simulate Druid", () => {
             "type": "expression"
           },
           {
-            "expression": "if(\"Count\"!=0,(cast(\"TotalPrice\",'DOUBLE')/\"Count\"),null)",
+            "expression": "if(\"Count\"!=0,(cast(\"TotalPrice\",'DOUBLE')/\"Count\"),0)",
             "name": "AvgPrice",
             "type": "expression"
           }
@@ -1644,8 +1644,8 @@ describe("simulate Druid", () => {
         SELECT
         SUM(price) AS 'TotalPrice'
         FROM \`diamonds\`
-        WHERE '2015-01-02T12:30:00' <= \`cut\` 
-        AND '2015-01-01T10:30:00' > \`color\` 
+        WHERE '2015-01-02T12:30:00' <= \`cut\`
+        AND '2015-01-01T10:30:00' > \`color\`
         AND '2015-01-01T10:30:00' <= \`time\` AND \`time\` < '2015-01-02T12:30:00'
       `).expression;
 
@@ -1690,8 +1690,8 @@ describe("simulate Druid", () => {
         SELECT
         SUM(prIcE) AS 'TotalPrice'
         FROM \`diamonds\`
-        WHERE '2015-01-02T12:30:00' <= \`cut\` 
-        AND '2015-01-01T10:30:00' > \`color\` 
+        WHERE '2015-01-02T12:30:00' <= \`cut\`
+        AND '2015-01-01T10:30:00' > \`color\`
         AND '2015-01-01T10:30:00' <= \`time\` AND \`time\` < '2015-01-02T12:30:00'
       `).expression;
 
@@ -2655,7 +2655,7 @@ describe("simulate Druid", () => {
             "type": "quantile"
           },
           {
-            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),null)",
+            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),0)",
             "name": "QuantileByRedPrice",
             "type": "expression"
           }
@@ -3204,7 +3204,7 @@ describe("simulate Druid", () => {
         "intervals": "2015-03-12T00Z/2015-03-19T00Z",
         "postAggregations": [
           {
-            "expression": "if(\"NumColors\"!=0,(cast(\"NumVendors\",'DOUBLE')/\"NumColors\"),null)",
+            "expression": "if(\"NumColors\"!=0,(cast(\"NumVendors\",'DOUBLE')/\"NumColors\"),0)",
             "name": "VendorsByColors",
             "type": "expression"
           }
@@ -3805,7 +3805,7 @@ describe("simulate Druid", () => {
         "intervals": "2015-03-12T00Z/2015-03-19T00Z",
         "postAggregations": [
           {
-            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),null)",
+            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),0)",
             "name": "__VALUE__",
             "type": "expression"
           }
@@ -3862,7 +3862,7 @@ describe("simulate Druid", () => {
         "intervals": "2015-03-12T00Z/2015-03-19T00Z",
         "postAggregations": [
           {
-            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),null)",
+            "expression": "if(\"!T_1\"!=0,(cast(\"!T_0\",'DOUBLE')/\"!T_1\"),0)",
             "name": "__VALUE__",
             "type": "expression"
           }


### PR DESCRIPTION
The bug was introduced in this changed line: https://github.com/implydata/plywood/commit/3e2bbfe71720ac988411998932b5c5f58464350b#diff-dbd531562931f21762b7891054c28718R269
it seems that the `null` is converted to a `STRING` that is not accepted by druid in a DivideExpression. Druid then returns an error, which is reported in https://github.com/implydata/plywood-druid-requester/blob/7aa70248bbcb4eb49168e54eddabeb16d1346f7d/src/druidRequester.ts#L375-L389 .
Based on these commits
https://github.com/implydata/plywood/commit/ef8dd1aca92895b586a9dc99b0bba80185c5db11
https://github.com/implydata/plywood/commit/418109a10d12fd6f4669bf67f6e2eab39becd72f
https://github.com/implydata/plywood/commit/97e286eceebf95d0bbe3f677b49fa3fd7df7872a
I think this bug is something that the people at implydata are still figuring out

[Time Shift Function in Pivot no longer working](https://trello.com/c/KHV8w0ar/4312-time-shift-function-in-pivot-no-longer-working)